### PR TITLE
implement velocity passthrough mode

### DIFF
--- a/src/control_position.h
+++ b/src/control_position.h
@@ -33,7 +33,8 @@ typedef struct {
 
 	bool paused;
 	bool unpause_requested;
-	bool stop_requested;
+	bool ptru_requested;
+	float ptru_vel;
 	bool direction_changed;
 
 	// params
@@ -57,6 +58,7 @@ void control_position_pause_if(control_position_t* cpos, bool pause);
 void control_position_pause(control_position_t* cpos);
 void control_position_unpause(control_position_t* cpos);
 void control_position_stop(control_position_t* cpos);
+void control_position_vel_ptru_mode(control_position_t* cpos, float vel);
 
 float control_position_stop_pos(const control_position_t* cpos);
 

--- a/src/control_position.hpp
+++ b/src/control_position.hpp
@@ -38,6 +38,10 @@ class PositionController {
             control_position_stop(&this->controller);
         };
 
+        void velPtruMode(float vel) {
+            control_position_vel_ptru_mode(&this->controller, vel);
+        };
+
         float stopPos() const {
             return control_position_stop_pos(&this->controller);
         };


### PR DESCRIPTION
previously, we could "disable" the position controller by calling
control_position_stop(). When disabled like this, the position
controller ramps down to velocity 0 and stays there.

we now extend this functionality to be able to disable the position
controller and keep a velocity *other than 0*, using the
control_position_ptru_mode() function. Calling it will cause the
controller's output to slowly ramp to the given velocity and stay there.