### PR TITLE
fix behaviour of position controller when coast speed is slow

### DIFF
--- a/src/math_utils.c
+++ b/src/math_utils.c
@@ -4,13 +4,16 @@
 
 // Scalar operations
 float signf(float x) {
-	if (x < 0) {
+	if (signbit(x)) {
 		return -1;
 	}
 	return 1;
 }
 
 float clampf(float x, float min, float max) {
+	if (min == 0.0f && max == 0.0f) {
+		return 0.0f * x;    // retain sign (signed zero ftw)
+	}
 	if (x < min) {
 		return min;
 	}


### PR DESCRIPTION
When using the position controller with vel_coast < vel_min, the vel output gets clamped to either 0 or -0 depending on direction. Due to incorrect handling of the -0 value in some math util functions, this resulted in the position controller never stopping.

The collateral damage of this is one (1) kitchen sink damaged by a robot who went on an unstoppable murder spree at a very slow speed.