### PR TITLE
control_velocity: explicit force-start and simpler rampdown

### DIFF
--- a/src/control_velocity.c
+++ b/src/control_velocity.c
@@ -13,10 +13,10 @@ void control_velocity_init(control_velocity_t* cvel, control_velocity_cfg_t* cfg
 	cvel->stable_start_achieved = false;
 	cvel->now_us                = 0;
 	cvel->rest_timer            = 0;
-	cvel->rest_integral         = 0;
 	cvel->ramp_speed            = INFINITY;
 	cvel->paused                = false;
 	cvel->unpause_requested     = false;
+	cvel->force_start_requested = false;
 }
 
 void control_velocity_pause_if(control_velocity_t* cpos, bool pause) {
@@ -78,36 +78,31 @@ void control_velocity_update(control_velocity_t* cvel, uint32_t now_us) {
 	}
 
 	// see if we should get out of a stopped state
-	if (minf(fabs(cvel->vel_target), fabs(cvel->vel_target_preramp)) >= vel_min) {
+	if (cvel->force_start_requested || minf(fabs(cvel->vel_target), fabs(cvel->vel_target_preramp)) >= vel_min) {
 		cvel->is_stopped    = false;
 		cvel->rest_timer    = now_us;
-		cvel->rest_integral = 0;
 	} else {
-		// a very overengineered solution to ramping down torque when stopping
-		// since torque goes up and down a lot while holding position, it must
-		// be averaged before we begin ramping it down
 		float time_elapsed_in_rest = calc_dt_from_timestamps_us(cvel->rest_timer, now_us);
 		if (!cvel->is_stopped && time_elapsed_in_rest > cvel->cfg->rest_timeout) {
-			// the torque output is the average torque during the last 30% of the timeout
-			cvel->torque_output         = cvel->rest_integral / (cvel->cfg->rest_timeout * 0.3);
 			cvel->is_stopped            = true;
 			cvel->stable_start_achieved = false;
-		} else if (!cvel->is_stopped && time_elapsed_in_rest > cvel->cfg->rest_timeout * 0.7) {
-			// start integrating when we are in the last 30% of the timeout
-			cvel->rest_integral += cvel->torque_output * dt;
 		}
 	}
+
+	cvel->force_start_requested = false;
 
 	// go limp if we're stopped
 	if (cvel->is_stopped) {
 		cvel->vel_target      = 0;
 		cvel->vel_err         = 0;
-		cvel->integral_torque = 0;
-		cvel->torque_output   = linear_ramp_to(
-            cvel->torque_output,
+
+		// smoothly rampdown integral torque to avoid jerky motion when stopping
+		cvel->integral_torque = linear_ramp_to(
+			cvel->integral_torque,
             cvel->cfg->torque_rampdown_speed * dt,
             0
         );
+        cvel->torque_output = cvel->integral_torque;
 		return;
 	}
 
@@ -164,4 +159,8 @@ void control_velocity_report_vel(control_velocity_t* cvel, float vel) {
 void control_velocity_target_vel(control_velocity_t* cvel, float vel, float ramp_speed) {
 	cvel->vel_target_preramp = vel;
 	cvel->ramp_speed         = ramp_speed;
+}
+
+void control_velocity_force_start(control_velocity_t* cvel) {
+	cvel->force_start_requested = true;
 }

--- a/src/control_velocity.c
+++ b/src/control_velocity.c
@@ -96,7 +96,7 @@ void control_velocity_update(control_velocity_t* cvel, uint32_t now_us) {
 		cvel->vel_target      = 0;
 		cvel->vel_err         = 0;
 
-		// smoothly rampdown integral torque to avoid jerky motion when stopping
+		// smoothly rampdown integral torque to avoid jerky motion when going limp
 		cvel->integral_torque = linear_ramp_to(
 			cvel->integral_torque,
             cvel->cfg->torque_rampdown_speed * dt,

--- a/src/control_velocity.h
+++ b/src/control_velocity.h
@@ -34,13 +34,13 @@ typedef struct {
 	// state
 	float    vel_err;
 	float    rest_timer;
-	float    rest_integral;
 	float    integral_torque;
 	uint32_t now_us;
 	bool     stable_start_achieved;
 
 	bool paused;
 	bool unpause_requested;
+	bool force_start_requested;
 
 	// params
 	float vel_target;
@@ -62,11 +62,15 @@ typedef struct {
 // structure and use them to control the motor.
 // Call control_velocity_target_vel() when you want to change velocity
 // If you don't want to ramp, use INFINITY as ramp_speed.
+// You generally don't need to call control_velocity_force_start() explicitly, unless you
+// want to force the velocity controller to act even if the target velocity is zero
+// (for example you want to use active braking).
 
 void control_velocity_init(control_velocity_t* cvel, control_velocity_cfg_t* cfg);
 void control_velocity_update(control_velocity_t* cvel, uint32_t now_us);
 void control_velocity_report_vel(control_velocity_t* cvel, float vel);
 void control_velocity_target_vel(control_velocity_t* cvel, float vel, float ramp_speed);
+void control_velocity_force_start(control_velocity_t* cvel);
 
 void control_velocity_pause_if(control_velocity_t* cvel, bool pause);
 void control_velocity_pause(control_velocity_t* cvel);


### PR DESCRIPTION
Before now, if you wanted to force the velocity controller to work even if the target velocity is zero (for example if you want to perform active braking), the only way was to set `is_stopped = false` externally. However, this resulted in buggy behaviour: if you do the `is_stopped = false` hack while the torque is still ramping down (because the velocity controller was switched off while applying high torque, for example if balancing a robot up a steep hill), the torque is reset back to the value it started ramping down from, resulting in sudden movement.

This commit fixes this bug by:
1. Adding an explicit `force_start` operation
2. Removing the overengineered `rest_integral` algorithm and replacing with a simple rampdown from the last integral_torque value

This algorithm was stupid in the first place: it addressed the problem of ramping down from a fluctuating torque while maintaining active brakes, but we can notice that this fluctuation is only present in the proportional term. If we instead set `torque_output = integral_torque` and rampdown from there, the problem disappears without having to resort to overengineered hacks.